### PR TITLE
DT-770: fix YARU-MATE theme not working

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,12 +22,14 @@ slots:
       read:
         - $SNAP/share/gtk2/Yaru-MATE-dark
         - $SNAP/share/gtk2/Yaru-MATE-light
+        - $SNAP/share/gtk2/Yaru-MATE
   gtk-3-themes:
     interface: content
     source:
       read:
         - $SNAP/share/themes/Yaru-MATE-dark
         - $SNAP/share/themes/Yaru-MATE-light
+        - $SNAP/share/themes/Yaru-MATE
 
 parts:
   theme:


### PR DESCRIPTION
When installing ubuntu-mate-themes, three themes are added to the list available in gnome-tweaks: Yaru MATE, Yaru MATE light and Yaru MATE dark. Unfortunately, the current snap for Yaru MATE themes only exports the light and dark variants, but not the "generic" one. The result is that selecting Yaru MATE in gnome tweaks always asks to download gtk-theme-yaru-mate, no matter that it is already installed, and the theme doesn't work on snap applications.

This patch fixes this.

Fix https://github.com/snapcore/snapd-desktop-integration/issues/16